### PR TITLE
Doc 5.10 样例代码错误，现已改正 

### DIFF
--- a/docs/4.0.0/5.10.md
+++ b/docs/4.0.0/5.10.md
@@ -54,7 +54,7 @@ if len(good)>MIN_MATCH_COUNT:
     dst_pts = np.float32([ kp2[m.trainIdx].pt for m in good ]).reshape(-1,1,2)
     M, mask = cv.findHomography(src_pts, dst_pts, cv.RANSAC,5.0)
     matchesMask = mask.ravel().tolist()
-    h,w,d = img1.shape
+    h,w= img1.shape
     pts = np.float32([ [0,0],[0,h-1],[w-1,h-1],[w-1,0] ]).reshape(-1,1,2)
     dst = cv.perspectiveTransform(pts,M)
     img2 = cv.polylines(img2,[np.int32(dst)],True,255,3, cv.LINE_AA)


### PR DESCRIPTION
```python
img1 = cv.imread('box.png',0)          # queryImage
....
h, w, d= img1.shape
```
由于 img1 为灰度图像，只有两个颜色通道，运行后会产生报错
```
ValueError: not enough values to unpack (expected 3, got 2)
```

现已改为 `h, w = img1.shape`